### PR TITLE
CODENVY-669 Make possible getting organizations by certain user

### DIFF
--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationModule.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationModule.java
@@ -15,6 +15,7 @@
 package com.codenvy.organization.api;
 
 import com.codenvy.api.permission.server.AbstractPermissionsDomain;
+import com.codenvy.api.permission.server.SystemDomain;
 import com.codenvy.api.permission.server.model.impl.AbstractPermissions;
 import com.codenvy.api.permission.server.spi.PermissionsDao;
 import com.codenvy.organization.api.permissions.OrganizationCreatorPermissionsProvider;
@@ -29,6 +30,7 @@ import com.codenvy.organization.spi.jpa.JpaOrganizationDao;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 
 /**
  * @author Sergii Leschenko
@@ -52,5 +54,10 @@ public class OrganizationModule extends AbstractModule {
         Multibinder<PermissionsDao<? extends AbstractPermissions>> storages =
                 Multibinder.newSetBinder(binder(), new TypeLiteral<PermissionsDao<? extends AbstractPermissions>>() {});
         storages.addBinding().to(JpaMemberDao.class);
+
+        final Multibinder<String> binder = Multibinder.newSetBinder(binder(),
+                                                                    String.class,
+                                                                    Names.named(SystemDomain.SYSTEM_DOMAIN_ACTIONS));
+        binder.addBinding().toInstance(OrganizationPermissionsFilter.MANAGE_ORGANIZATIONS_ACTION);
     }
 }

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationService.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationService.java
@@ -176,20 +176,24 @@ public class OrganizationService extends Service {
 
     @GET
     @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Get memberships of current user",
+    @ApiOperation(value = "Get user's organizations",
+                  notes = "When user parameter is missed then will be fetched current user's organizations",
                   response = OrganizationDto.class,
                   responseContainer = "list")
     @ApiResponses({@ApiResponse(code = 200, message = "The organizations successfully fetched"),
                    @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
-    public Response getOrganizations(@ApiParam(value = "Max items") @QueryParam("maxItems") @DefaultValue("30") int maxItems,
+    public Response getOrganizations(@ApiParam(value = "User id") @QueryParam("user") String userId,
+                                     @ApiParam(value = "Max items") @QueryParam("maxItems") @DefaultValue("30") int maxItems,
                                      @ApiParam(value = "Skip count") @QueryParam("skipCount") @DefaultValue("0") int skipCount)
             throws ServerException, BadRequestException {
 
         checkArgument(maxItems >= 0, "The number of items to return can't be negative.");
         checkArgument(skipCount >= 0, "The number of items to skip can't be negative.");
-        final String currentUserId = EnvironmentContext.getCurrent().getSubject().getUserId();
-        final Page<? extends Organization> organizationsPage = organizationManager.getByMember(currentUserId, maxItems, skipCount);
+        if (userId == null) {
+            userId = EnvironmentContext.getCurrent().getSubject().getUserId();
+        }
+        final Page<? extends Organization> organizationsPage = organizationManager.getByMember(userId, maxItems, skipCount);
         return Response.ok()
                        .entity(organizationsPage.getItems(organization -> linksInjector.injectLinks(asDto(organization),
                                                                                                     getServiceContext())))

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/permissions/OrganizationPermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/permissions/OrganizationPermissionsFilter.java
@@ -14,6 +14,7 @@
  */
 package com.codenvy.organization.api.permissions;
 
+import com.codenvy.api.permission.server.SystemDomain;
 import com.codenvy.organization.api.OrganizationManager;
 import com.codenvy.organization.api.OrganizationService;
 import com.codenvy.organization.shared.dto.OrganizationDto;
@@ -82,8 +83,17 @@ public class OrganizationPermissionsFilter extends CheMethodInvokerFilter {
                 //anybody can create root organization
                 return;
 
-            //methods accessible to every user
             case "getOrganizations":
+                final String userId = (String)arguments[0];
+                if (userId != null
+                    && !userId.equals(currentSubject.getUserId())
+                    && !currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_CODENVY_ACTION)) {
+                    throw new ForbiddenException("The user is able to specify only own id");
+                }
+                //user specified his user id or has required permission
+                return;
+
+            //methods accessible to every user
             case "getById":
             case "find":
                 return;


### PR DESCRIPTION
### What does this PR do?

Makes possible getting organizations by certain user
### What issues does this PR fix or reference?

https://github.com/codenvy/codenvy/issues/669
### Previous Behavior

There was possible get organization only by current user
### New Behavior

Only 'admin' can get organization by certain user. Other users are able to get only own organizations
### Tests written?

Yes
